### PR TITLE
Update egui to the latest version (0.29.1).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,13 +15,13 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-egui = { version = "0.28.1", default-features = false }
+egui = { version = "0.29.1", default-features = false }
 twemoji-assets = { version = "1.3.0", default-features = false }
 unicode-segmentation = "1.11.0"
 
 [dev-dependencies]
-eframe = "0.28.1"
-egui_extras = { version = "0.28.1", features = ["svg"] }
+eframe = "0.29.1"
+egui_extras = { version = "0.29.1", features = ["svg"] }
 
 [features]
 default = ["svg"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,6 +196,7 @@ fn empty_response(ctx: egui::Context) -> egui::Response {
         is_pointer_button_down_on: false,
         interact_pointer_pos: None,
         changed: false,
+        intrinsic_size: None,
     }
 }
 


### PR DESCRIPTION
Hi, I stumbled across this project while I was prototyping with an egui project using the latest version of egui (`0.29.1`) when I noticed the crate needed some version bumping to function with the current version of egui so here we go.

It seems to work and the tests pass.

![image](https://github.com/user-attachments/assets/f7e82c1d-f0a3-4904-b6a0-5630ad264d49)